### PR TITLE
Instructions for enabling secret scanning and push protection for the Security Baseline

### DIFF
--- a/operations/github/ent-secret-scanning/README.md
+++ b/operations/github/ent-secret-scanning/README.md
@@ -1,15 +1,38 @@
 # Secret Scanning policy implementation #
 
 
-Process and code (API calls) for implementing secret scanning and push protection for secrets at the enterprise level in the OpenSSF ententerprise.
+This includes a python utility to check and implement the secret scanning and push protection enterprise policies.  This utility requires a GH PAT with the permissions to read and write at the Enterprise level ("read:enterprise" and "admin:enterprise").  It is best to create tokens for temporary use.  This assumes the token is stored in a local file.  Unfortunately, there is no means of testing the API calls for updating enterprise level policies without actually changing the enterprise-level policies.  However, there are tests included to call other endpoints with similar functions to try and ensure that the functions should work
+
+## Use of the 
+
+Usage is as follows:
+
+python secretscanning.py -t <tokenfile> -c <command>
+
+tokenfile is the path of the file containing only the github PAT
+<command> is one of the following: 
+	check -- this checks and reports on the secret scanning policy and the push protection policy
+		example: 'python secretscanning.py -t token -c check'
+	set -- this checks the policies, updates them to the target state with both enabled, and then verifies and reports on the active settings
+		example: 'python secretscanning.py -t token -c set'
+	rollback -- this command removes the settings, then checks and reports on the settings to ensure they are disabled
+		example: 'python secretscanning.py -t token -c rollback'
+		
+	run_tests -- This command is used with 2 other options to test the PATCH and GET functions against other endpoints of the Github API, specifically the repository API endpoint.  Here we are testing that the functions to update and check the properties of an object (PATCH for update, GET for reading).  The options are:
+		-r = repository to test against
+		-d = description of the repository to change
+		example: 
+		'''python secretscanning.py -t repo_token -c run_tests -r bbp-test/bbp-test -d newdescription'''
+	The "check" function can also be used to test.
+
+
+## API Call reference
 
 Based upon the documentation: https://docs.github.com/en/enterprise-cloud@latest/rest/enterprise-admin/code-security-and-analysis?apiVersion=2022-11-28#update-code-security-and-analysis-features-for-an-enterprise
 
-These are intended to be run as individual CLI calls (with proper handling of the API token -- replacing the "<YOUR-TOKEN>" string), run after review for correctness and as a means to avoid human error in the GUI.  
 The token used should be scoped to have the "admin:enterprise" permission for implementation and "read:enterprise" for verification.
 
-
-## Implementation ##
+### API Call to implement ###
 '''
 curl -L \
   -X PATCH \
@@ -22,7 +45,7 @@ curl -L \
 Should return "Status 204"
 
 
-## Verification ##
+### API Call to Check Exisiting Policies for Verification ##
 '''
 curl -L \
   -H "Accept: application/vnd.github+json" \
@@ -39,7 +62,7 @@ Should return with status 200 and a JSON document with at least these features a
   }
 '''
 
-### Dry Run
+### Example
 
 To do a "dry run" you can run the verification step to verify the setup is working.  There is no way to do a test / dry run of the implementation step, as it will actually implement the change.
 

--- a/operations/github/ent-secret-scanning/README.md
+++ b/operations/github/ent-secret-scanning/README.md
@@ -1,0 +1,59 @@
+# Secret Scanning policy implementation #
+
+
+Process and code (API calls) for implementing secret scanning and push protection for secrets at the enterprise level in the OpenSSF ententerprise.
+
+Based upon the documentation: https://docs.github.com/en/enterprise-cloud@latest/rest/enterprise-admin/code-security-and-analysis?apiVersion=2022-11-28#update-code-security-and-analysis-features-for-an-enterprise
+
+These are intended to be run as individual CLI calls (with proper handling of the API token -- replacing the "<YOUR-TOKEN>" string), run after review for correctness and as a means to avoid human error in the GUI.  
+The token used should be scoped to have the "admin:enterprise" permission for implementation and "read:enterprise" for verification.
+
+
+## Implementation ##
+'''
+curl -L \
+  -X PATCH \
+  -H "Accept: application/vnd.github+json" \
+  -H "Authorization: Bearer <YOUR-TOKEN>" \
+  -H "X-GitHub-Api-Version: 2022-11-28" \
+  https://api.github.com/enterprises/openssf/code_security_and_analysis \
+  -d '{"secret_scanning_enabled_for_new_repositories":true,"secret_scanning_push_protection_enabled_for_new_repositories":true}'
+'''
+Should return "Status 204"
+
+
+## Verification ##
+'''
+curl -L \
+  -H "Accept: application/vnd.github+json" \
+  -H "Authorization: Bearer <YOUR-TOKEN>" \
+  -H "X-GitHub-Api-Version: 2022-11-28" \
+  https://api.github.com/enterprises/openssf/code_security_and_analysis
+'''
+
+Should return with status 200 and a JSON document with at least these features as true:
+'''
+  {
+  "secret_scanning_enabled_for_new_repositories": true,
+  "secret_scanning_push_protection_enabled_for_new_repositories": true
+  }
+'''
+
+### Dry Run
+
+To do a "dry run" you can run the verification step to verify the setup is working.  There is no way to do a test / dry run of the implementation step, as it will actually implement the change.
+
+
+with a temporary API TOKEN scoped to only "read:enterprise" in the file named "token":
+'''
+curl -L -H "Accept: application/vnd.github+json" -H "Authorization: Bearer `cat token`" -H "X-GitHub-Api-Version: 2022-11-28" https://api.github.com/enterprises/openssf/code_security_and_analysis
+{
+  "advanced_security_enabled_for_new_repositories": false,
+  "dependabot_alerts_enabled_for_new_repositories": true,
+  "secret_scanning_enabled_for_new_repositories": true,
+  "secret_scanning_push_protection_enabled_for_new_repositories": false,
+  "secret_scanning_push_protection_custom_link": null
+}
+'''
+
+

--- a/operations/github/ent-secret-scanning/README.md
+++ b/operations/github/ent-secret-scanning/README.md
@@ -3,7 +3,7 @@
 
 This includes a python utility to check and implement the secret scanning and push protection enterprise policies.  This utility requires a GH PAT with the permissions to read and write at the Enterprise level ("read:enterprise" and "admin:enterprise").  It is best to create tokens for temporary use.  This assumes the token is stored in a local file.  Unfortunately, there is no means of testing the API calls for updating enterprise level policies without actually changing the enterprise-level policies.  However, there are tests included to call other endpoints with similar functions to try and ensure that the functions should work
 
-## Use of the 
+## Use of the python utility
 
 Usage is as follows:
 
@@ -12,11 +12,11 @@ python secretscanning.py -t <tokenfile> -c <command>
 tokenfile is the path of the file containing only the github PAT
 <command> is one of the following: 
 	check -- this checks and reports on the secret scanning policy and the push protection policy
-		example: 'python secretscanning.py -t token -c check'
+		example: `python secretscanning.py -t token -c check`
 	set -- this checks the policies, updates them to the target state with both enabled, and then verifies and reports on the active settings
-		example: 'python secretscanning.py -t token -c set'
+		example: `python secretscanning.py -t token -c set`
 	rollback -- this command removes the settings, then checks and reports on the settings to ensure they are disabled
-		example: 'python secretscanning.py -t token -c rollback'
+		example: `python secretscanning.py -t token -c rollback`
 		
 	run_tests -- This command is used with 2 other options to test the PATCH and GET functions against other endpoints of the Github API, specifically the repository API endpoint.  Here we are testing that the functions to update and check the properties of an object (PATCH for update, GET for reading).  The options are:
 		-r = repository to test against
@@ -28,12 +28,12 @@ tokenfile is the path of the file containing only the github PAT
 
 ## API Call reference
 
-Based upon the documentation: https://docs.github.com/en/enterprise-cloud@latest/rest/enterprise-admin/code-security-and-analysis?apiVersion=2022-11-28#update-code-security-and-analysis-features-for-an-enterprise
+Based upon the [documentation](https://docs.github.com/en/enterprise-cloud@latest/rest/enterprise-admin/code-security-and-analysis?apiVersion=2022-11-28#update-code-security-and-analysis-features-for-an-enterprise)
 
 The token used should be scoped to have the "admin:enterprise" permission for implementation and "read:enterprise" for verification.
 
 ### API Call to implement ###
-'''
+```
 curl -L \
   -X PATCH \
   -H "Accept: application/vnd.github+json" \
@@ -41,26 +41,26 @@ curl -L \
   -H "X-GitHub-Api-Version: 2022-11-28" \
   https://api.github.com/enterprises/openssf/code_security_and_analysis \
   -d '{"secret_scanning_enabled_for_new_repositories":true,"secret_scanning_push_protection_enabled_for_new_repositories":true}'
-'''
+```
 Should return "Status 204"
 
 
 ### API Call to Check Exisiting Policies for Verification ##
-'''
+```
 curl -L \
   -H "Accept: application/vnd.github+json" \
   -H "Authorization: Bearer <YOUR-TOKEN>" \
   -H "X-GitHub-Api-Version: 2022-11-28" \
   https://api.github.com/enterprises/openssf/code_security_and_analysis
-'''
+```
 
 Should return with status 200 and a JSON document with at least these features as true:
-'''
+```
   {
   "secret_scanning_enabled_for_new_repositories": true,
   "secret_scanning_push_protection_enabled_for_new_repositories": true
   }
-'''
+```
 
 ### Example
 
@@ -68,7 +68,7 @@ To do a "dry run" you can run the verification step to verify the setup is worki
 
 
 with a temporary API TOKEN scoped to only "read:enterprise" in the file named "token":
-'''
+```
 curl -L -H "Accept: application/vnd.github+json" -H "Authorization: Bearer `cat token`" -H "X-GitHub-Api-Version: 2022-11-28" https://api.github.com/enterprises/openssf/code_security_and_analysis
 {
   "advanced_security_enabled_for_new_repositories": false,
@@ -77,6 +77,6 @@ curl -L -H "Accept: application/vnd.github+json" -H "Authorization: Bearer `cat 
   "secret_scanning_push_protection_enabled_for_new_repositories": false,
   "secret_scanning_push_protection_custom_link": null
 }
-'''
+```
 
 

--- a/operations/github/ent-secret-scanning/secretscanning.py
+++ b/operations/github/ent-secret-scanning/secretscanning.py
@@ -63,8 +63,7 @@ def disable_secret_scanning_and_push_protection_settings(access_token):
 
     if response.status_code == 204:
             return True
-    else:
-        print(f"Error: Response code is invalid for updating security policies")
+    print("Error: Response code is invalid for updating security policies")
     return False
 
 

--- a/operations/github/ent-secret-scanning/secretscanning.py
+++ b/operations/github/ent-secret-scanning/secretscanning.py
@@ -1,0 +1,155 @@
+import requests
+import sys
+
+# Utility function to run a GET against the API
+def api_get(access_token, url):
+    try:
+        headers = {"Authorization": f"Bearer {access_token}"}
+        return requests.get(url, headers=headers)
+    except Exception as e:
+        print (f"Error while running API GET. {e}.")
+        exit
+
+def get_secret_scanning_and_push_protection_settings(access_token):
+    url = f"https://api.github.com/enterprises/openssf/code_security_and_analysis"
+    
+    response = api_get(access_token=access_token, url=url)
+
+    if response.status_code == 200:
+        settings = response.json()
+        secret_scanning_enabled = settings.get("secret_scanning_enabled_for_new_repositories", {})
+        push_protection_enabled = settings.get("secret_scanning_push_protection_enabled_for_new_repositories", {})
+        return secret_scanning_enabled, push_protection_enabled
+    else:
+        print(f"Error: Unable to retrieve settings. Status code: {response.status_code}")
+        return None, None
+
+        
+def check_policies(access_token):
+    print(f"Checking current settings.")
+    secret_scanning, push_protection = get_secret_scanning_and_push_protection_settings(access_token)
+    if secret_scanning is not None and push_protection is not None:
+        print(f"Secret Scanning enabled: {secret_scanning}")
+        print(f"Push Protection enabled: {push_protection}")
+    else:
+        print("Error occurred while fetching settings.")
+
+
+# Utility function for calling the PATCH method on the Github API
+def api_patch(access_token, url, data):
+    try:
+        headers = {"Authorization": f"Bearer {access_token}"}
+        return requests.patch(url, json=data, headers=headers)
+    except Exception as e:
+        print(f"Error: {e}")
+        exit
+        
+# Set the policies
+def set_secret_scanning_and_push_protection_settings(access_token):
+    url = "https://api.github.com/enterprises/openssf/code_security_and_analysis"
+    data = {"secret_scanning_enabled_for_new_repositories":True,"secret_scanning_push_protection_enabled_for_new_repositories":True}
+    response = api_patch(access_token, url, json=data)
+    if response.status_code == 204:
+        return True
+    else:
+        print(f"Error: Response code is invalid for updating security policies")
+        return False
+
+# Unset the policies               
+def disable_secret_scanning_and_push_protection_settings(access_token):
+    url = "https://api.github.com/enterprises/openssf/code_security_and_analysis"
+    data = {"secret_scanning_enabled_for_new_repositories":False,"secret_scanning_push_protection_enabled_for_new_repositories":False}
+    response = api_patch(access_token, url, json=data)
+
+    if response.status_code == 204:
+            return True
+    else:
+        print(f"Error: Response code is invalid for updating security policies")
+    return False
+
+
+# Tests to make sure that the calls to PATCH and GET for handling of object properties works
+# This tests an entirely different endpoint, but uses the same methods and formats
+def run_api_tests(api_token, repository, desc):
+    url = f"https://api.github.com/repos/" + repository
+    data = {"description":desc,"private":True}
+
+    # PATCH call to update object properties
+    response = api_patch(access_token, url, data)
+
+
+    if response.status_code == 200:
+        print ("successful test for PATCH of repo info")
+    else:
+        print ("test failed for PATCH of repo")
+        print (response.status_code)
+        print (response.content)
+        exit
+
+    # get data to validate update to properties
+    try:
+        response = api_get(access_token, url)
+        if response.status_code == 200:
+            settings = response.json()
+            if settings.get("description") == desc:
+                print("success")
+            else:
+                print("fail")
+        else:
+            print ("Failed pulling properties.")
+            exit
+
+    except Exception as e:
+        print (f"Failed calling API GET: {e}")
+
+def usage():
+    print("python secretscanning.py -t token_filename -c <set|rollback|check|test")
+    print("token_filename = supply a filename which contains a valid github API token.")
+    print("choose \"set\" to set the polcies, \"rollback\" to rollback the policies, or leave blank to report the current settings.")
+
+def parse_arguments():
+    args = {}
+    for i in range(1, len(sys.argv), 2):
+        flag = sys.argv[i]
+        value = sys.argv[i + 1] if i + 1 < len(sys.argv) else None
+        if flag.startswith("-"):
+            args[flag] = value
+    return args
+
+access_token = "placeholder"
+
+arguments = parse_arguments()
+tokenfile= arguments.get("-t")
+command = arguments.get("-c")
+testrepo = arguments.get("-r")
+desc = arguments.get("-d")
+
+try:
+    with open(tokenfile, 'r') as file:
+        access_token = file.read().rstrip()
+except Exception as e:
+    print(f"Error accessing token file: {e}")
+
+if (command == "run_tests"):
+    run_api_tests(access_token, testrepo, desc)
+
+if command == "check":
+    check_policies(access_token)
+
+if (command == "set"):
+    if (set_secret_scanning_and_push_protection_settings(access_token)):
+        print(f"Setting policy successful, validating...")
+        check_policies(access_token)
+    else:
+        print(f"Setting policies failed, please check logs and try again.")
+
+if (command == "rollback"):
+    if (disable_secret_scanning_and_push_protection_settings(access_token)):
+        print(f"Setting policy successful, validating...")
+        check_policies(access_token)
+    else:
+        print(f"Rollback failed, please check logs and try again.")
+
+        
+
+

--- a/operations/github/ent-secret-scanning/secretscanning.py
+++ b/operations/github/ent-secret-scanning/secretscanning.py
@@ -48,7 +48,7 @@ def api_patch(access_token, url, data):
 def set_secret_scanning_and_push_protection_settings(access_token):
     url = "https://api.github.com/enterprises/openssf/code_security_and_analysis"
     data = {"secret_scanning_enabled_for_new_repositories":True,"secret_scanning_push_protection_enabled_for_new_repositories":True}
-    response = api_patch(access_token, url, json=data)
+    response = api_patch(access_token, url, data)
     if response.status_code == 204:
         return True
     else:
@@ -59,7 +59,7 @@ def set_secret_scanning_and_push_protection_settings(access_token):
 def disable_secret_scanning_and_push_protection_settings(access_token):
     url = "https://api.github.com/enterprises/openssf/code_security_and_analysis"
     data = {"secret_scanning_enabled_for_new_repositories":False,"secret_scanning_push_protection_enabled_for_new_repositories":False}
-    response = api_patch(access_token, url, json=data)
+    response = api_patch(access_token, url, data)
 
     if response.status_code == 204:
             return True


### PR DESCRIPTION
Some simple instructions for updating the Enterprise policy for enabling the secret scanning and push protection per the recent TAC approval of this for the security baseline.  This is intended to be done simply with the API to minimize human error in the UI and that there has been more than one person reviewing what is being implemented.